### PR TITLE
Update applyChangeToValue.js

### DIFF
--- a/src/utils/applyChangeToValue.js
+++ b/src/utils/applyChangeToValue.js
@@ -13,11 +13,11 @@ const applyChangeToValue = (
   let oldPlainTextValue = getPlainText(value, config)
 
   let lengthDelta = oldPlainTextValue.length - plainTextValue.length
-  if (selectionStartBefore === 'undefined') {
+  if (selectionStartBefore === 'undefined' || selectionStartBefore == null) {
     selectionStartBefore = selectionEndAfter + lengthDelta
   }
 
-  if (selectionEndBefore === 'undefined') {
+  if (selectionEndBefore === 'undefined' || selectionEndBefore == null) {
     selectionEndBefore = selectionStartBefore
   }
 


### PR DESCRIPTION
On MS Edge, type in some text and make at least one typographical error. Click on the typo to see suggested spellings and select one. If you select a corrected spelling, the text essentially doubles, leaving the corrected version and the uncorrected one.

Fixes #ABC

What did you change (functionally and technically)?
-- Added extra check for null value for  selectionStartBefore and selectionEndBefore in applyChangeToValue function.

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code?
* Does the code comply to our code conventions?
* Does the PR resolve the whole issue?

**Additional review hints** (remove this list before you submit the PR)
* Besides the code review, what should the reviewer test?
* Are there any edge cases?
* Do you have any test files or test set-up?
* Could your changes cause side effects elsewhere in the code base?
